### PR TITLE
planex.repo: Include release type in repository name

### DIFF
--- a/SOURCES/planex.repo.in
+++ b/SOURCES/planex.repo.in
@@ -1,11 +1,11 @@
-[planex]
+[planex-@RELEASE_TYPE@]
 name=Planex
 baseurl=https://xenserver.github.io/planex-release/@RELEASE_TYPE@/rpm/@DIST@/@DIST_VERSION@
 gpgcheck=0
 Priority=1
 enabled=1
 
-[planex-source]
+[planex-@RELEASE_TYPE@-source]
 name=Planex Source
 baseurl=https://xenserver.github.io/planex-release/@RELEASE_TYPE@/rpm/@DIST@/@DIST_VERSION@
 gpgcheck=0


### PR DESCRIPTION
This is necessary to allow planex-release and planex-unstable to be
installed at the same time, or even for unstable to replace release
without the need to clear the yum metadata cache manually.

Signed-off-by: Euan Harris euan.harris@citrix.com
